### PR TITLE
Fix "bad math expression" and "destination already exists" errors with the README.md "git clone" instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ echo "source ~/zsh-tmux-auto-title/zsh-tmux-auto-title.plugin.zsh" >>! ~/.zshrc
 ### Oh My Zsh:
 
 ```
-git clone --depth=1 https://github.com/mbenford/zsh-tmux-auto-title ${ZSH_CUSTOM:~/.oh-my-zsh/custom}/plugins
+git clone --depth=1 https://github.com/mbenford/zsh-tmux-auto-title "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-tmux-auto-title"
+
 ```
 
 Add `zsh-tmux-auto-title` to `plugins` in `.zshrc`.


### PR DESCRIPTION
1st fix:
```zsh
❯ git clone --depth=1 https://github.com/mbenford/zsh-tmux-auto-title ${ZSH_CUSTOM:~/.oh-my-zsh/custom}/plugins
zsh: bad math expression: operand expected at `/.oh-my-zs...'
```

2nd fix:
```zsh
❯ git clone --depth=1 https://github.com/mbenford/zsh-tmux-auto-title "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins"
fatal: destination path '[...]/oh-my-zsh/custom/plugins' already exists and is not an empty directory.
```