### PR TITLE
Add an option to show idle text before cmd name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ If you are using Oh My Zsh you should also set `DISABLE_AUTO_TITLE=true` in your
 | `ZSH_TMUX_AUTO_TITLE_IDLE_TEXT` | Text to be used when no command is running. It can be either a plain string or one of the following variables: <br>`%pwd`: current directory; <br>`%shell`: current shell;<br>`%last`: last command, prefixed by an exclamation mark.<br>Defaults to `%shell`. |
 | `ZSH_TMUX_AUTO_TITLE_IDLE_DELAY` | Delay, in seconds, before the idle text is displayed. Defaults to `1`. |
 | `ZSH_TMUX_AUTO_TITLE_PREFIX` | A prefix added to the title, Defaults to `""`. |
+| `ZSH_TMUX_AUTO_TITLE_ALWAYS_SHOW_IDLE_TEXT` | Show `ZSH_TMUX_AUTO_TITLE_IDLE_TEXT` before running cmd name.  |
 


### PR DESCRIPTION
I want to keep an eye on the path running the cmd, so I added this option, the effect is like this:
<img width="911" alt="image" src="https://github.com/mbenford/zsh-tmux-auto-title/assets/19600697/06a4396f-c3ee-4c46-9828-da9f3fe27045">